### PR TITLE
fix: set isDefaultHidden even if there is only one variant

### DIFF
--- a/views/layouts/pen.nunj
+++ b/views/layouts/pen.nunj
@@ -11,8 +11,8 @@
 {% if entity.isComponent %}
     {% if entity.variants().size > 1 %}
         {% set previewUrl = path(frctl.theme.urlFromRoute('preview', {handle: entity.variants().default().handle})) %}
-        {% set isDefaultHidden = entity.variants().default().isHidden %}
     {% endif %}
+    {% set isDefaultHidden = entity.variants().default().isHidden %}
 {% endif %}
 
 {% block content %}


### PR DESCRIPTION
If a component only has one variant (the default), which is hidden (for example, to just show a README), the preview button next to the title is still rendered.

Turns out the `isDefaultHidden` variable is currently only set if there are at least 2 variants.

I'm assuming the default variant always implicitly exists and we don't need a `size > 0` condition, but I'm not completely sure.